### PR TITLE
Branch commit fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 Sui Version Manager (`suivm`) is a tool for managing multiple versions of Sui CLI.
 
+Sui publishes pre-compiled binaries which can be downloaded using `suivm` to speed up your workflow.
+
 ## Install
 
 Install `suivm` using `cargo`:
 
 ```bash
-cargo install --git https://github.com/origin-byte/suivm --locked
+cargo install --git https://github.com/origin-byte/suivm
 ```
 
 Verify the installation:
@@ -16,3 +18,13 @@ Verify the installation:
 suivm use latest
 sui --version
 ```
+
+`suivm` supports resolving tags, branches, and commit hashes:
+
+```bash
+suivm use devnet-0.27.0
+suivm use devnet
+suivm use 157ac72030d014f17d76cefe81f3915b4afab2c9
+```
+
+`suivm` will automatically download pre-compiled binary if a matching tag like `devnet-0.27.0` is provided.


### PR DESCRIPTION
- Allows branch or commit hash to be specified as versions to install
- Handles cases where download is interrupted midway leading to a corrupted installation
- Correctly registers binary after compiling